### PR TITLE
Combining totems in a crafting grid creates a new random totem.

### DIFF
--- a/src/main/java/org/cyclops/everlastingabilities/EverlastingAbilities.java
+++ b/src/main/java/org/cyclops/everlastingabilities/EverlastingAbilities.java
@@ -205,10 +205,10 @@ public class EverlastingAbilities extends ModBaseVersionable {
                 return MutableAbilityStoreConfig.CAPABILITY;
             }
         });
-		
-		if (ItemAbilityTotemConfig.totemCraftingCount > 0) {
-			GameRegistry.addRecipe(new TotemRecycleRecipe());
-		}
+        
+        if (ItemAbilityTotemConfig.totemCraftingCount > 0) {
+            GameRegistry.addRecipe(new TotemRecycleRecipe());
+        }
     }
     
     /**

--- a/src/main/java/org/cyclops/everlastingabilities/EverlastingAbilities.java
+++ b/src/main/java/org/cyclops/everlastingabilities/EverlastingAbilities.java
@@ -32,6 +32,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.*;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.logging.log4j.Level;
 import org.cyclops.cyclopscore.command.CommandMod;
 import org.cyclops.cyclopscore.config.ConfigHandler;
@@ -67,6 +68,7 @@ import org.cyclops.everlastingabilities.item.ItemAbilityBottle;
 import org.cyclops.everlastingabilities.item.ItemAbilityBottleConfig;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotem;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotemConfig;
+import org.cyclops.everlastingabilities.recipe.TotemRecycleRecipe;
 import org.cyclops.everlastingabilities.network.packet.RequestAbilityStorePacket;
 
 import javax.annotation.Nullable;
@@ -203,6 +205,10 @@ public class EverlastingAbilities extends ModBaseVersionable {
                 return MutableAbilityStoreConfig.CAPABILITY;
             }
         });
+		
+		if (ItemAbilityTotemConfig.totemCraftingCount > 0) {
+			GameRegistry.addRecipe(new TotemRecycleRecipe());
+		}
     }
     
     /**

--- a/src/main/java/org/cyclops/everlastingabilities/ability/AbilityHelpers.java
+++ b/src/main/java/org/cyclops/everlastingabilities/ability/AbilityHelpers.java
@@ -3,6 +3,7 @@ package org.cyclops.everlastingabilities.ability;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.EnumRarity;
+import net.minecraft.item.ItemStack;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cyclops.cyclopscore.helper.Helpers;
 import org.cyclops.cyclopscore.helper.obfuscation.ObfuscationHelpers;
@@ -14,6 +15,7 @@ import org.cyclops.everlastingabilities.api.IAbilityType;
 import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
 import org.cyclops.everlastingabilities.api.capability.IMutableAbilityStore;
 import org.cyclops.everlastingabilities.capability.MutableAbilityStoreConfig;
+import org.cyclops.everlastingabilities.item.ItemAbilityTotem;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -68,8 +70,10 @@ public class AbilityHelpers {
 
     /**
      * Add the given ability.
+	 * @param player The player.
      * @param ability The ability.
      * @param doAdd If the addition should actually be done.
+	 * @param modifyXp Whether to require player to have enough XP before adding
      * @return The ability part that was added.
      */
     public static @Nullable Ability addPlayerAbility(EntityPlayer player, Ability ability, boolean doAdd, boolean modifyXp) {
@@ -111,8 +115,10 @@ public class AbilityHelpers {
 
     /**
      * Remove the given ability.
+	 * @param player The player.
      * @param ability The ability.
      * @param doRemove If the removal should actually be done.
+	 * @param modifyXp Whether to refund XP cost of ability
      * @return The ability part that was removed.
      */
     public static @Nullable Ability removePlayerAbility(EntityPlayer player, Ability ability, boolean doRemove, boolean modifyXp) {
@@ -174,6 +180,12 @@ public class AbilityHelpers {
         }
         return null;
     }
+
+    public static ItemStack getRandomTotem(EnumRarity rarity, Random rand) {
+        IAbilityType abilityType = getRandomAbility(rand, rarity);
+        return ItemAbilityTotem.getInstance().getTotem(new Ability(abilityType, 1));
+    }
+    
 
     public static EnumRarity getRandomRarity(Random rand) {
         int chance = rand.nextInt(50);

--- a/src/main/java/org/cyclops/everlastingabilities/ability/AbilityHelpers.java
+++ b/src/main/java/org/cyclops/everlastingabilities/ability/AbilityHelpers.java
@@ -70,10 +70,10 @@ public class AbilityHelpers {
 
     /**
      * Add the given ability.
-	 * @param player The player.
+     * @param player The player.
      * @param ability The ability.
      * @param doAdd If the addition should actually be done.
-	 * @param modifyXp Whether to require player to have enough XP before adding
+     * @param modifyXp Whether to require player to have enough XP before adding
      * @return The ability part that was added.
      */
     public static @Nullable Ability addPlayerAbility(EntityPlayer player, Ability ability, boolean doAdd, boolean modifyXp) {
@@ -115,10 +115,10 @@ public class AbilityHelpers {
 
     /**
      * Remove the given ability.
-	 * @param player The player.
+     * @param player The player.
      * @param ability The ability.
      * @param doRemove If the removal should actually be done.
-	 * @param modifyXp Whether to refund XP cost of ability
+     * @param modifyXp Whether to refund XP cost of ability
      * @return The ability part that was removed.
      */
     public static @Nullable Ability removePlayerAbility(EntityPlayer player, Ability ability, boolean doRemove, boolean modifyXp) {

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/AbilityStoreDisplayType.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/AbilityStoreDisplayType.java
@@ -1,0 +1,52 @@
+package org.cyclops.everlastingabilities.api.capability;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.TextFormatting;
+import org.cyclops.everlastingabilities.api.Ability;
+import org.cyclops.cyclopscore.helper.L10NHelpers;
+import java.util.List;
+
+/**
+ * Display type for ability stores.  Used to control how abilities should be displayed.
+ * @author CplPibald
+ */
+
+ // DisplayTypes:
+ //
+ // NORMAL = Use when abilities are known
+ // OBFUSCATED = Use when abilities are not known
+ 
+public abstract class AbilityStoreDisplayType {
+
+    public static AbilityStoreDisplayType NORMAL = new AbilityStoreDisplayType() {
+        @Override
+        public void addInformation(IAbilityStore abilityStore, ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean advanced) {
+            // Display each ability in store, one line at a time
+            // Or display "none" string if list is empty
+            boolean empty = true;
+            for (Ability ability : abilityStore.getAbilities()) {
+                empty = false;
+                String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
+                list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
+            }
+            if (empty) {
+                list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
+            }
+        }
+    };
+    
+    public static AbilityStoreDisplayType OBFUSCATED = new AbilityStoreDisplayType() {
+        @Override
+        public void addInformation(IAbilityStore abilityStore, ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean advanced) {
+            // Ability display is obfuscated.  
+            // This only blocks display in item tooltip.  Player can still view abilities by activating totem.
+            list.add(TextFormatting.OBFUSCATED.toString() + "Obfuscated");
+        }
+    };
+
+    //-------
+    // Called when displaying tooltip for an ItemStack that has an ability store attached
+    //-------
+    public abstract void addInformation(IAbilityStore abilityStore, ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean advanced);
+}

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class DefaultAbilityStore implements IAbilityStore {
 
     protected final Map<IAbilityType, Integer> abilityTypes = Maps.newLinkedHashMap();
-    protected DisplayType displayType = DisplayType.NORMAL;
+    protected AbilityStoreDisplayType displayType = AbilityStoreDisplayType.NORMAL;
 
     public DefaultAbilityStore() {
 
@@ -65,7 +65,7 @@ public class DefaultAbilityStore implements IAbilityStore {
     }
 
     @Override
-    public DisplayType getDisplayType() {
+    public AbilityStoreDisplayType getDisplayType() {
         return displayType;
     }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
@@ -16,8 +16,8 @@ import java.util.Map;
 public class DefaultAbilityStore implements IAbilityStore {
 
     protected final Map<IAbilityType, Integer> abilityTypes = Maps.newLinkedHashMap();
-	protected DisplayType displayType = DisplayType.NORMAL;
-	
+    protected DisplayType displayType = DisplayType.NORMAL;
+
     public DefaultAbilityStore() {
 
     }
@@ -63,9 +63,9 @@ public class DefaultAbilityStore implements IAbilityStore {
         }
         return new Ability(abilityType, abilityTypes.get(abilityType));
     }
-	
-	@Override
-	public DisplayType getDisplayType() {
-		return displayType;
-	}
+
+    @Override
+    public DisplayType getDisplayType() {
+        return displayType;
+    }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultAbilityStore.java
@@ -16,7 +16,8 @@ import java.util.Map;
 public class DefaultAbilityStore implements IAbilityStore {
 
     protected final Map<IAbilityType, Integer> abilityTypes = Maps.newLinkedHashMap();
-
+	protected DisplayType displayType = DisplayType.NORMAL;
+	
     public DefaultAbilityStore() {
 
     }
@@ -62,4 +63,9 @@ public class DefaultAbilityStore implements IAbilityStore {
         }
         return new Ability(abilityType, abilityTypes.get(abilityType));
     }
+	
+	@Override
+	public DisplayType getDisplayType() {
+		return displayType;
+	}
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
@@ -57,9 +57,9 @@ public class DefaultMutableAbilityStore extends DefaultAbilityStore implements I
         }
         return removedAbility;
     }
-	
-	@Override
-	public void setDisplayType(DisplayType type) {
-		displayType = type;
-	}
+
+    @Override
+    public void setDisplayType(DisplayType type) {
+        displayType = type;
+    }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
@@ -57,4 +57,9 @@ public class DefaultMutableAbilityStore extends DefaultAbilityStore implements I
         }
         return removedAbility;
     }
+	
+	@Override
+	public void setDisplayType(DisplayType type) {
+		displayType = type;
+	}
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/DefaultMutableAbilityStore.java
@@ -59,7 +59,7 @@ public class DefaultMutableAbilityStore extends DefaultAbilityStore implements I
     }
 
     @Override
-    public void setDisplayType(DisplayType type) {
+    public void setDisplayType(AbilityStoreDisplayType type) {
         displayType = type;
     }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
@@ -18,10 +18,5 @@ public interface IAbilityStore {
     public Collection<Ability> getAbilities();
     public Map<IAbilityType, Integer> getAbilitiesRaw();
     public Ability getAbility(IAbilityType abilityType);
-    public DisplayType getDisplayType();
-
-    public enum DisplayType {
-        NORMAL,
-        OBFUSCATED;
-    }
+    public AbilityStoreDisplayType getDisplayType();
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
@@ -18,10 +18,10 @@ public interface IAbilityStore {
     public Collection<Ability> getAbilities();
     public Map<IAbilityType, Integer> getAbilitiesRaw();
     public Ability getAbility(IAbilityType abilityType);
-	public DisplayType getDisplayType();
-	
-	public enum DisplayType {
-		NORMAL,
-		OBFUSCATED;
-	}
+    public DisplayType getDisplayType();
+
+    public enum DisplayType {
+        NORMAL,
+        OBFUSCATED;
+    }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IAbilityStore.java
@@ -18,5 +18,10 @@ public interface IAbilityStore {
     public Collection<Ability> getAbilities();
     public Map<IAbilityType, Integer> getAbilitiesRaw();
     public Ability getAbility(IAbilityType abilityType);
-
+	public DisplayType getDisplayType();
+	
+	public enum DisplayType {
+		NORMAL,
+		OBFUSCATED;
+	}
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
@@ -26,4 +26,10 @@ public interface IMutableAbilityStore extends IAbilityStore {
      */
     public @Nullable Ability removeAbility(Ability ability, boolean doRemove);
 
+	
+    /**
+     * Set display type for the ability store.
+     * @param type the type to set
+     */
+	 public void setDisplayType(DisplayType type);
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
@@ -31,5 +31,5 @@ public interface IMutableAbilityStore extends IAbilityStore {
      * Set display type for the ability store.
      * @param type the type to set
      */
-    public void setDisplayType(DisplayType type);
+    public void setDisplayType(AbilityStoreDisplayType type);
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/IMutableAbilityStore.java
@@ -26,10 +26,10 @@ public interface IMutableAbilityStore extends IAbilityStore {
      */
     public @Nullable Ability removeAbility(Ability ability, boolean doRemove);
 
-	
+
     /**
      * Set display type for the ability store.
      * @param type the type to set
      */
-	 public void setDisplayType(DisplayType type);
+    public void setDisplayType(DisplayType type);
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
@@ -25,7 +25,7 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
 
     private final ItemStack itemStack;
 
-	protected DisplayType displayType = DisplayType.NORMAL;
+    protected DisplayType displayType = DisplayType.NORMAL;
 
     public ItemStackMutableAbilityStore(ItemStack itemStack) {
         this.itemStack = itemStack;
@@ -104,13 +104,13 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
         return store.getAbility(abilityType);
     }
 
-	@Override
-	public DisplayType getDisplayType() {
-		return displayType;
-	}
+    @Override
+    public DisplayType getDisplayType() {
+        return displayType;
+    }
 
-	@Override
-	public void setDisplayType(DisplayType type) {
-		displayType = type;
-	}
+    @Override
+    public void setDisplayType(DisplayType type) {
+        displayType = type;
+    }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
@@ -25,7 +25,7 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
 
     private final ItemStack itemStack;
 
-    protected DisplayType displayType = DisplayType.NORMAL;
+    protected AbilityStoreDisplayType displayType = AbilityStoreDisplayType.NORMAL;
 
     public ItemStackMutableAbilityStore(ItemStack itemStack) {
         this.itemStack = itemStack;
@@ -105,12 +105,12 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
     }
 
     @Override
-    public DisplayType getDisplayType() {
+    public AbilityStoreDisplayType getDisplayType() {
         return displayType;
     }
 
     @Override
-    public void setDisplayType(DisplayType type) {
+    public void setDisplayType(AbilityStoreDisplayType type) {
         displayType = type;
     }
 }

--- a/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
+++ b/src/main/java/org/cyclops/everlastingabilities/api/capability/ItemStackMutableAbilityStore.java
@@ -25,6 +25,8 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
 
     private final ItemStack itemStack;
 
+	protected DisplayType displayType = DisplayType.NORMAL;
+
     public ItemStackMutableAbilityStore(ItemStack itemStack) {
         this.itemStack = itemStack;
     }
@@ -101,4 +103,14 @@ public class ItemStackMutableAbilityStore implements IMutableAbilityStore {
         IMutableAbilityStore store = getInnerStore();
         return store.getAbility(abilityType);
     }
+
+	@Override
+	public DisplayType getDisplayType() {
+		return displayType;
+	}
+
+	@Override
+	public void setDisplayType(DisplayType type) {
+		displayType = type;
+	}
 }

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotem.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotem.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.everlastingabilities.ability.AbilityTypes;
+import org.cyclops.everlastingabilities.ability.AbilityHelpers;
 import org.cyclops.everlastingabilities.api.Ability;
 import org.cyclops.everlastingabilities.api.IAbilityType;
 import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
@@ -62,6 +63,12 @@ public class ItemAbilityTotem extends ItemGuiAbilityContainer {
         return itemStack;
     }
 
+	public static ItemStack getRandomTotem(java.util.Random rand) {
+		EnumRarity rarity = AbilityHelpers.getRandomRarity(rand);
+		IAbilityType abilityType = AbilityHelpers.getRandomAbility(rand, rarity);
+		return getInstance().getTotem(new Ability(abilityType, 1));
+	}
+	
     @Override
     public void getSubItems(Item itemIn, CreativeTabs tab, NonNullList<ItemStack> subItems) {
         for (IAbilityType abilityType : AbilityTypes.REGISTRY.getAbilityTypes()) {

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotem.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotem.java
@@ -7,7 +7,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.everlastingabilities.ability.AbilityTypes;
-import org.cyclops.everlastingabilities.ability.AbilityHelpers;
 import org.cyclops.everlastingabilities.api.Ability;
 import org.cyclops.everlastingabilities.api.IAbilityType;
 import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
@@ -63,12 +62,6 @@ public class ItemAbilityTotem extends ItemGuiAbilityContainer {
         return itemStack;
     }
 
-	public static ItemStack getRandomTotem(java.util.Random rand) {
-		EnumRarity rarity = AbilityHelpers.getRandomRarity(rand);
-		IAbilityType abilityType = AbilityHelpers.getRandomAbility(rand, rarity);
-		return getInstance().getTotem(new Ability(abilityType, 1));
-	}
-	
     @Override
     public void getSubItems(Item itemIn, CreativeTabs tab, NonNullList<ItemStack> subItems) {
         for (IAbilityType abilityType : AbilityTypes.REGISTRY.getAbilityTypes()) {

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotemConfig.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotemConfig.java
@@ -41,7 +41,13 @@ public class ItemAbilityTotemConfig extends ItemConfig {
      */
     @ConfigurableProperty(category = ConfigurableTypeCategory.CORE, comment = "This many totems combined in a crafting grid produces a new random totem (0 to disable)")
     public static int totemCraftingCount = 3;
-	
+
+    /**
+     * Percent chance that combined totem will have a rarity bump
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.CORE, comment = "When combining totems, percentage chance of getting one higher rarity than normal.")
+    public static int totemCraftingRarityIncreasePercent = 15;
+
     /**
      * Make a new instance.
      */

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotemConfig.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemAbilityTotemConfig.java
@@ -37,6 +37,12 @@ public class ItemAbilityTotemConfig extends ItemConfig {
     public static boolean lootChests = true;
 
     /**
+     * Can totems be combined in the crafting grid
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.CORE, comment = "This many totems combined in a crafting grid produces a new random totem (0 to disable)")
+    public static int totemCraftingCount = 3;
+	
+    /**
      * Make a new instance.
      */
     public ItemAbilityTotemConfig() {

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
@@ -54,29 +54,29 @@ public abstract class ItemGuiAbilityContainer extends ItemGui {
         super.addInformation(itemStack, entityPlayer, list, par4);
         IAbilityStore abilityStore = itemStack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
 
-		switch(abilityStore.getDisplayType()) {
-			case NORMAL: {
-				// Normal display of abilities
-				boolean empty = true;
-				for (Ability ability : abilityStore.getAbilities()) {
-					empty = false;
-					String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
-					list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
-				}
-				if (empty) {
-					list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
-				}
-				break;
-			}
-			
-			case OBFUSCATED: {
-				// Ability display is obfuscated.  
-				// This only blocks display in item tooltip.  Player can still view abilities by activating totem.
-				list.add(TextFormatting.OBFUSCATED.toString() + "Obfuscated");
-				break;
-			}
-		}
-		
+        switch(abilityStore.getDisplayType()) {
+            case NORMAL: {
+                // Normal display of abilities
+                boolean empty = true;
+                for (Ability ability : abilityStore.getAbilities()) {
+                    empty = false;
+                    String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
+                    list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
+                }
+                if (empty) {
+                    list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
+                }
+                break;
+            }
+            
+            case OBFUSCATED: {
+                // Ability display is obfuscated.  
+                // This only blocks display in item tooltip.  Player can still view abilities by activating totem.
+                list.add(TextFormatting.OBFUSCATED.toString() + "Obfuscated");
+                break;
+            }
+        }
+        
     }
 
     @Override

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
@@ -5,15 +5,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
-import org.cyclops.cyclopscore.helper.L10NHelpers;
 import org.cyclops.cyclopscore.item.ItemGui;
 import org.cyclops.cyclopscore.modcompat.capabilities.DefaultCapabilityProvider;
-import org.cyclops.everlastingabilities.api.Ability;
 import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
 import org.cyclops.everlastingabilities.api.capability.IMutableAbilityStore;
 import org.cyclops.everlastingabilities.api.capability.ItemStackMutableAbilityStore;
@@ -54,29 +51,7 @@ public abstract class ItemGuiAbilityContainer extends ItemGui {
         super.addInformation(itemStack, entityPlayer, list, par4);
         IAbilityStore abilityStore = itemStack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
 
-        switch(abilityStore.getDisplayType()) {
-            case NORMAL: {
-                // Normal display of abilities
-                boolean empty = true;
-                for (Ability ability : abilityStore.getAbilities()) {
-                    empty = false;
-                    String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
-                    list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
-                }
-                if (empty) {
-                    list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
-                }
-                break;
-            }
-            
-            case OBFUSCATED: {
-                // Ability display is obfuscated.  
-                // This only blocks display in item tooltip.  Player can still view abilities by activating totem.
-                list.add(TextFormatting.OBFUSCATED.toString() + "Obfuscated");
-                break;
-            }
-        }
-        
+        abilityStore.getDisplayType().addInformation(abilityStore, itemStack, entityPlayer, list, par4);
     }
 
     @Override

--- a/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
+++ b/src/main/java/org/cyclops/everlastingabilities/item/ItemGuiAbilityContainer.java
@@ -53,15 +53,30 @@ public abstract class ItemGuiAbilityContainer extends ItemGui {
     public void addInformation(ItemStack itemStack, EntityPlayer entityPlayer, List list, boolean par4) {
         super.addInformation(itemStack, entityPlayer, list, par4);
         IAbilityStore abilityStore = itemStack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
-        boolean empty = true;
-        for (Ability ability : abilityStore.getAbilities()) {
-            empty = false;
-            String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
-            list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
-        }
-        if (empty) {
-            list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
-        }
+
+		switch(abilityStore.getDisplayType()) {
+			case NORMAL: {
+				// Normal display of abilities
+				boolean empty = true;
+				for (Ability ability : abilityStore.getAbilities()) {
+					empty = false;
+					String name = L10NHelpers.localize(ability.getAbilityType().getUnlocalizedName());
+					list.add(TextFormatting.YELLOW + name + ": " + TextFormatting.RESET + ability.getLevel());
+				}
+				if (empty) {
+					list.add(TextFormatting.GRAY.toString() + TextFormatting.ITALIC + L10NHelpers.localize("general.everlastingabilities.empty"));
+				}
+				break;
+			}
+			
+			case OBFUSCATED: {
+				// Ability display is obfuscated.  
+				// This only blocks display in item tooltip.  Player can still view abilities by activating totem.
+				list.add(TextFormatting.OBFUSCATED.toString() + "Obfuscated");
+				break;
+			}
+		}
+		
     }
 
     @Override

--- a/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
+++ b/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
@@ -8,7 +8,9 @@ import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.world.World;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.ForgeHooks;
+import org.cyclops.cyclopscore.helper.MinecraftHelpers;
 import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
+import org.cyclops.everlastingabilities.api.capability.AbilityStoreDisplayType;
 import org.cyclops.everlastingabilities.api.capability.IMutableAbilityStore;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotem;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotemConfig;
@@ -18,13 +20,11 @@ import java.util.Random;
 
 public class TotemRecycleRecipe implements IRecipe {
 
-    private World _world = null;
+    private final Random rand = new Random();
     
     @Override
     public boolean matches(InventoryCrafting invCrafting, World world) {
     
-        _world = world;
-
         int inputCount = 0;
         for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
             ItemStack slot = invCrafting.getStackInSlot(i);
@@ -43,13 +43,13 @@ public class TotemRecycleRecipe implements IRecipe {
     
     @Override
     public ItemStack getCraftingResult(InventoryCrafting invCrafting) {
-        if (_world.isRemote) {
+        if (MinecraftHelpers.isClientSide()) {
         
             // Getting item for display in crafting output.
             // User hasn't picked it up yet, so display an obfuscated name.
             ItemStack stack = new ItemStack(ItemAbilityTotem.getInstance());
             IMutableAbilityStore abilityStore = stack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
-            abilityStore.setDisplayType(IAbilityStore.DisplayType.OBFUSCATED);
+            abilityStore.setDisplayType(AbilityStoreDisplayType.OBFUSCATED);
         
             return stack;
         }
@@ -58,7 +58,7 @@ public class TotemRecycleRecipe implements IRecipe {
             
             // Select one of the inputs at random, and use its rarity for the rarity of the output.
             int inputIndex = 0;
-            int inputTargetIndex = _world.rand.nextInt(ItemAbilityTotemConfig.totemCraftingCount);
+            int inputTargetIndex = rand.nextInt(ItemAbilityTotemConfig.totemCraftingCount);
             EnumRarity rarity = EnumRarity.COMMON;
             
             for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
@@ -81,11 +81,11 @@ public class TotemRecycleRecipe implements IRecipe {
             }
             
             // 20% chance of a bump
-            if (rarity.ordinal() < EnumRarity.EPIC.ordinal() && _world.rand.nextInt(100) < ItemAbilityTotemConfig.totemCraftingRarityIncreasePercent) {
+            if (rarity.ordinal() < EnumRarity.EPIC.ordinal() && rand.nextInt(100) < ItemAbilityTotemConfig.totemCraftingRarityIncreasePercent) {
                 rarity = EnumRarity.values()[rarity.ordinal()+1];
             }
             
-            return AbilityHelpers.getRandomTotem(rarity, _world.rand);
+            return AbilityHelpers.getRandomTotem(rarity, rand);
         }
     }
 

--- a/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
+++ b/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
@@ -1,0 +1,56 @@
+package org.cyclops.everlastingabilities.recipe;
+
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.ItemStack;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.world.World;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.ForgeHooks;
+import org.cyclops.everlastingabilities.item.ItemAbilityTotem;
+import org.cyclops.everlastingabilities.item.ItemAbilityTotemConfig;
+import java.util.Random;
+
+public class TotemRecycleRecipe implements IRecipe {
+
+	static final Random rand = new Random();
+
+	@Override
+	public boolean matches(InventoryCrafting invCrafting, World world) {
+	
+		int inputCount = 0;
+		
+		for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
+			ItemStack slot = invCrafting.getStackInSlot(i);
+			if (!slot.isEmpty()) {
+				if (slot.getItem() instanceof ItemAbilityTotem) {
+					inputCount++;
+				}
+				else {
+					// non-totem item found in recipe
+					return false;
+				}
+			}
+		}
+		return inputCount == ItemAbilityTotemConfig.totemCraftingCount;
+	}
+	
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting invCrafting) {
+		return ItemAbilityTotem.getRandomTotem(rand);
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return new ItemStack(ItemAbilityTotem.getInstance());
+	}
+	
+	@Override
+	public int getRecipeSize() {
+		return 3;
+	}
+	
+	@Override
+	public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+		return ForgeHooks.defaultRecipeGetRemainingItems(inv);
+	}
+}

--- a/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
+++ b/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
@@ -2,55 +2,102 @@ package org.cyclops.everlastingabilities.recipe;
 
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.EnumRarity;
+import net.minecraft.item.Item;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.world.World;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.ForgeHooks;
+import org.cyclops.everlastingabilities.api.capability.IAbilityStore;
+import org.cyclops.everlastingabilities.api.capability.IMutableAbilityStore;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotem;
 import org.cyclops.everlastingabilities.item.ItemAbilityTotemConfig;
+import org.cyclops.everlastingabilities.ability.AbilityHelpers;
+import org.cyclops.everlastingabilities.capability.MutableAbilityStoreConfig;
 import java.util.Random;
 
 public class TotemRecycleRecipe implements IRecipe {
 
-	static final Random rand = new Random();
+    private World _world = null;
+    
+    @Override
+    public boolean matches(InventoryCrafting invCrafting, World world) {
+    
+        _world = world;
 
-	@Override
-	public boolean matches(InventoryCrafting invCrafting, World world) {
-	
-		int inputCount = 0;
-		
-		for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
-			ItemStack slot = invCrafting.getStackInSlot(i);
-			if (!slot.isEmpty()) {
-				if (slot.getItem() instanceof ItemAbilityTotem) {
-					inputCount++;
-				}
-				else {
-					// non-totem item found in recipe
-					return false;
-				}
-			}
-		}
-		return inputCount == ItemAbilityTotemConfig.totemCraftingCount;
-	}
-	
-	@Override
-	public ItemStack getCraftingResult(InventoryCrafting invCrafting) {
-		return ItemAbilityTotem.getRandomTotem(rand);
-	}
+        int inputCount = 0;
+        for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
+            ItemStack slot = invCrafting.getStackInSlot(i);
+            if (!slot.isEmpty()) {
+                if (slot.getItem() instanceof ItemAbilityTotem) {
+                    inputCount++;
+                }
+                else {
+                    // non-totem item found in recipe
+                    return false;
+                }
+            }
+        }
+        return inputCount == ItemAbilityTotemConfig.totemCraftingCount;
+    }
+    
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting invCrafting) {
+        if (_world.isRemote) {
+        
+            // Getting item for display in crafting output.
+			// User hasn't picked it up yet, so display an obfuscated name.
+            ItemStack stack = new ItemStack(ItemAbilityTotem.getInstance());
+			IMutableAbilityStore abilityStore = stack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
+			abilityStore.setDisplayType(IAbilityStore.DisplayType.OBFUSCATED);
+        
+            return stack;
+        }
+        else {
+            // Item is being taken out of crafting grid.
+            
+			// Select one of the inputs at random, and use its rarity for the rarity of the output.
+			int inputIndex = 0;
+			int inputTargetIndex = _world.rand.nextInt(ItemAbilityTotemConfig.totemCraftingCount);
+			EnumRarity rarity = EnumRarity.COMMON;
+			
+            for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
+                ItemStack slot = invCrafting.getStackInSlot(i);
+                if (!slot.isEmpty()) {
+                    if (slot.getItem() instanceof ItemAbilityTotem) {
+                        if (inputIndex >= inputTargetIndex) { 
+							rarity = ItemAbilityTotem.getInstance().getRarity(slot);
+							break;
+						}
+						inputIndex++;
+                    }
+                    else {
+                        // non-totem item found in recipe
+						// this should never happen because matches() will return false.
+						// We should probably throw() here.
+                        return ItemStack.EMPTY;
+                    }
+                }
+            }
 
-	@Override
-	public ItemStack getRecipeOutput() {
-		return new ItemStack(ItemAbilityTotem.getInstance());
-	}
-	
-	@Override
-	public int getRecipeSize() {
-		return 3;
-	}
-	
-	@Override
-	public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
-		return ForgeHooks.defaultRecipeGetRemainingItems(inv);
-	}
+            return AbilityHelpers.getRandomTotem(rarity, _world.rand);
+        }
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return new ItemStack(ItemAbilityTotem.getInstance());
+    }
+    
+    @Override
+    public int getRecipeSize() {
+        return 3;
+    }
+    
+    @Override
+    public NonNullList<ItemStack> getRemainingItems(InventoryCrafting inv) {
+        return ForgeHooks.defaultRecipeGetRemainingItems(inv);
+    }
+
 }
+

--- a/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
+++ b/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
@@ -46,40 +46,45 @@ public class TotemRecycleRecipe implements IRecipe {
         if (_world.isRemote) {
         
             // Getting item for display in crafting output.
-			// User hasn't picked it up yet, so display an obfuscated name.
+            // User hasn't picked it up yet, so display an obfuscated name.
             ItemStack stack = new ItemStack(ItemAbilityTotem.getInstance());
-			IMutableAbilityStore abilityStore = stack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
-			abilityStore.setDisplayType(IAbilityStore.DisplayType.OBFUSCATED);
+            IMutableAbilityStore abilityStore = stack.getCapability(MutableAbilityStoreConfig.CAPABILITY, null);
+            abilityStore.setDisplayType(IAbilityStore.DisplayType.OBFUSCATED);
         
             return stack;
         }
         else {
             // Item is being taken out of crafting grid.
             
-			// Select one of the inputs at random, and use its rarity for the rarity of the output.
-			int inputIndex = 0;
-			int inputTargetIndex = _world.rand.nextInt(ItemAbilityTotemConfig.totemCraftingCount);
-			EnumRarity rarity = EnumRarity.COMMON;
-			
+            // Select one of the inputs at random, and use its rarity for the rarity of the output.
+            int inputIndex = 0;
+            int inputTargetIndex = _world.rand.nextInt(ItemAbilityTotemConfig.totemCraftingCount);
+            EnumRarity rarity = EnumRarity.COMMON;
+            
             for (int i = 0; i < invCrafting.getSizeInventory(); i++) {
                 ItemStack slot = invCrafting.getStackInSlot(i);
                 if (!slot.isEmpty()) {
                     if (slot.getItem() instanceof ItemAbilityTotem) {
                         if (inputIndex >= inputTargetIndex) { 
-							rarity = ItemAbilityTotem.getInstance().getRarity(slot);
-							break;
-						}
-						inputIndex++;
+                            rarity = ItemAbilityTotem.getInstance().getRarity(slot);
+                            break;
+                        }
+                        inputIndex++;
                     }
                     else {
                         // non-totem item found in recipe
-						// this should never happen because matches() will return false.
-						// We should probably throw() here.
+                        // this should never happen because matches() will return false.
+                        // We should probably throw() here.
                         return ItemStack.EMPTY;
                     }
                 }
             }
-
+            
+            // 20% chance of a bump
+            if (rarity.ordinal() < EnumRarity.EPIC.ordinal() && _world.rand.nextInt(100) < ItemAbilityTotemConfig.totemCraftingRarityIncreasePercent) {
+                rarity = EnumRarity.values()[rarity.ordinal()+1];
+            }
+            
             return AbilityHelpers.getRandomTotem(rarity, _world.rand);
         }
     }


### PR DESCRIPTION
Fixes #37

Adds a custom recipe that takes N totems (configurable) in a crafting grid and produces
a new totem with a random level 1 ability.

Open issues:
1) No JEI integration.  Recipe does not show up in JEI
2) Crafting output slot shows a totem with a random ability that is usually not the random ability as you get when you take the item.  A better solution would show a totem with ability text "???" when in the crafting output slot, but `IRecipe.getCraftingResult()` doesn't distinguish between the ItemStack in the output slot and in the picked up result.