### PR TITLE
Power Stare only activates when player is sneaking

### DIFF
--- a/src/main/java/org/cyclops/everlastingabilities/ability/AbilityTypePowerStare.java
+++ b/src/main/java/org/cyclops/everlastingabilities/ability/AbilityTypePowerStare.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.cyclops.cyclopscore.helper.MinecraftHelpers;
+import org.cyclops.everlastingabilities.ability.config.AbilityPowerStareConfig;
 
 import java.util.List;
 
@@ -28,6 +29,11 @@ public class AbilityTypePowerStare extends AbilityTypeDefault {
 
     @Override
     public void onTick(EntityPlayer player, int level) {
+    
+        if ( AbilityPowerStareConfig.requireSneak && !player.isSneaking() ) {
+            return;
+        }
+
         World world = player.world;
         if (!world.isRemote && player.world.getWorldTime() % TICK_MODULUS == 0) {
             int range = level * 10;

--- a/src/main/java/org/cyclops/everlastingabilities/ability/config/AbilityPowerStareConfig.java
+++ b/src/main/java/org/cyclops/everlastingabilities/ability/config/AbilityPowerStareConfig.java
@@ -29,7 +29,12 @@ public class AbilityPowerStareConfig extends AbilityConfig {
      */
     @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, categoryRaw = "ability", comment = "The xp required per level.", requiresMcRestart = true)
     public static int xpPerLevel = 50;
-
+    /**
+     * If true, Power Stare only works while crouching
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, categoryRaw = "ability", comment = "Require sneak to activate.", requiresMcRestart = false)
+    public static boolean requireSneak = true;
+    
     /**
      * The unique instance.
      */


### PR DESCRIPTION
Power Stare only activates when player is sneaking
Add config to toggle whether sneaking is required (default enabled)
resolves #40 