### PR TITLE
Remove hardcoded value from TotemRecycleRecipe.getRecipeSize()

### DIFF
--- a/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
+++ b/src/main/java/org/cyclops/everlastingabilities/recipe/TotemRecycleRecipe.java
@@ -96,7 +96,7 @@ public class TotemRecycleRecipe implements IRecipe {
     
     @Override
     public int getRecipeSize() {
-        return 3;
+        return ItemAbilityTotemConfig.totemCraftingCount;
     }
     
     @Override


### PR DESCRIPTION
Fix for bug left in #37 - `getRecipeSize()` was originally hardcoded to 3 and I forgot to update it to use `ItemAbilityTotemConfig.totemCraftingCount` when I added the config.